### PR TITLE
Add support for Zorin OS (panel)

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -124,6 +124,13 @@ function check_os_comp {
     else
       SUPPORTED=false
     fi
+  elif [ "$OS" == "zorin" ]; then
+    if [ "$OS_VER_MAJOR" == "15" ]; then
+      SUPPORTED=true
+      PHP_SOCKET="/run/php/php7.2-fpm.sock"
+    else
+      SUPPORTED=false
+    fi
   elif [ "$OS" == "debian" ]; then
     if [ "$OS_VER_MAJOR" == "8" ]; then
       SUPPORTED=true
@@ -219,7 +226,7 @@ function configure {
 # set the correct folder permissions depending on OS and webserver
 function set_folder_permissions {
   # if os is ubuntu or debian, we do this
-  if [ "$OS" == "debian" ] || [ "$OS" == "ubuntu" ]; then
+  if [ "$OS" == "debian" ] || [ "$OS" == "ubuntu" ] || [ "$OS" == "zorin" ]; then
     chown -R www-data:www-data ./*
   elif [ "$OS" == "centos" ] && [ "$WEBSERVER" == "nginx" ]; then
     chown -R nginx:nginx ./*
@@ -557,6 +564,21 @@ function perform_install {
       ubuntu16_dep
     else
       print_error "Unsupported version of Ubuntu."
+      exit 1
+    fi
+    install_composer
+    ptdl_dl
+    create_database
+    configure
+    insert_cronjob
+    install_pteroq
+  elif [ "$OS" == "zorin" ]; then
+    ubuntu_universedep
+    apt_update
+    if [ "$OS_VER_MAJOR" == "15" ]; then
+      ubuntu18_dep
+    else
+      print_error "Unsupported version of Zorin."
       exit 1
     fi
     install_composer


### PR DESCRIPTION
I was experimenting with Zorin as that's all I had laying around on a USB Stick at the time, as the OS is built on top of Ubuntu 18 there isn't much difference in the OS other than the overhauled UI. So I changed your script to include it locally. Just suggesting the change in case anyone else uses this. I was able to install and use it with those changes.