### PR TITLE
Add "--unsafe-perm" parameter to "npm install"

### DIFF
--- a/install-daemon.sh
+++ b/install-daemon.sh
@@ -293,7 +293,7 @@ function ptdl_dl {
   cd /srv/daemon || exit
 
   curl -L "$DL_URL" | tar --strip-components=1 -xzv
-  npm install --only=production
+  npm install --only=production --unsafe-perm
 
   echo "* Done."
 }


### PR DESCRIPTION
several people have reported that node-gyp is unable to install "mmmagic" due to some permission screw-up. See the linked issue.
this commit adds the "--unsafe-perm" parameter which tells npm to ignore the errors and proceed with install

Fixes #30