### PR TITLE
Package not installed when function is ran

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -479,8 +479,8 @@ function centos8_dep {
 #################################
 
 function ubuntu_universedep {
-  #Probably should change this, this is more of a bandaid fix for this 
-  #This function running before software-properties-common is installed
+  # Probably should change this, this is more of a bandaid fix for this 
+  # This function is ran before software-properties-common is installed
   apt update -y
   apt install software-properties-common -y
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -479,6 +479,11 @@ function centos8_dep {
 #################################
 
 function ubuntu_universedep {
+  #Probably should change this, this is more of a bandaid fix for this 
+  #This function running before software-properties-common is installed
+  apt update -y
+  apt install software-properties-common -y
+
   if grep -q universe "$SOURCES_PATH"; then
     # even if it detects it as already existent, we'll still run the apt command to make sure
     add-apt-repository universe


### PR DESCRIPTION
The package software-properties-common isn't installed before the command it provides (add-apt-repository) is ran.
The fix basically installs the necessary package. Though it is suggestion that this package is installed another way, or since the command 'apt install software-properties-common -y' is already within the script, that command should be ran before this script.

Though for now, this fixes the error message the start of running the script saying "Error: add-apt-repository. command not found"

Fixes #34