### PR TITLE
Fixing nginx stopping the script

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -666,7 +666,12 @@ function configure_nginx {
   fi
 
   # restart nginx
-  systemctl restart nginx
+  if [ "$CONFIGURE_LETSENCRYPT" == true ] || { [ "$CONFIGURE_LETSENCRYPT" == false ] && [ "$ASSUME_SSL" == false ]; }; then
+    systemctl restart nginx
+  else
+    print_error "Fatal error" # Should never happen
+    exit 1
+  fi
   echo "* nginx configured!"
 }
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -668,9 +668,6 @@ function configure_nginx {
   # restart nginx
   if [ "$CONFIGURE_LETSENCRYPT" == true ] || { [ "$CONFIGURE_LETSENCRYPT" == false ] && [ "$ASSUME_SSL" == false ]; }; then
     systemctl restart nginx
-  else
-    print_error "Fatal error" # Should never happen
-    exit 1
   fi
   echo "* nginx configured!"
 }


### PR DESCRIPTION
When you choose ASSUME_SSL true, and LETSENCRYPT false the nginx will fail at the end of the script. This fixes that.