### PR TITLE
panel: setsebool commands on CentOS can now fail without abort

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -538,9 +538,9 @@ function centos7_dep {
   systemctl start redis
 
   # SELinux (allow nginx and redis)
-  setsebool -P httpd_can_network_connect 1
-  setsebool -P httpd_execmem 1
-  setsebool -P httpd_unified 1
+  setsebool -P httpd_can_network_connect 1 || true  # these commands can fail OK
+  setsebool -P httpd_execmem 1 || true
+  setsebool -P httpd_unified 1 || true
 
   echo "* Dependencies for CentOS installed!"
 }
@@ -574,9 +574,9 @@ function centos8_dep {
   systemctl start redis
 
   # SELinux (allow nginx and redis)
-  setsebool -P httpd_can_network_connect 1
-  setsebool -P httpd_execmem 1
-  setsebool -P httpd_unified 1
+  setsebool -P httpd_can_network_connect 1 || true  # these commands can fail OK
+  setsebool -P httpd_execmem 1 || true
+  setsebool -P httpd_unified 1 || true
 
   echo "* Dependencies for CentOS installed!"
 }


### PR DESCRIPTION
If the `setsebool` commands fail they will no longer cause the script to abort

Fixes #106
