### PR TITLE
Just tried to make the password section better.

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -137,7 +137,7 @@ required_input() {
 
 password_input() {
   local result=$1
-  echo -e "Please enter the password that is used throughout the install. (Use something strong)"
+  echo -n "* ${2}"
   while [[ -z "$password_main" || ! $password_main == $password_confirm ]]
     do
       read -sp "Password: " password_main && echo
@@ -885,7 +885,7 @@ function main {
   [ -z "$MYSQL_USER_INPUT" ] && MYSQL_USER="pterodactyl" || MYSQL_USER=$MYSQL_USER_INPUT
 
   # MySQL password input
-  password_input MYSQL_PASSWORD
+  password_input MYSQL_PASSWORD "Password (use something strong): "
 
   valid_timezones="$(timedatectl list-timezones)"
   echo "* List of valid timezones here $(hyperlink "https://www.php.net/manual/en/timezones.php")"
@@ -906,7 +906,7 @@ function main {
   required_input user_username "Username for the initial admin account: " "Username cannot be empty"
   required_input user_firstname "First name for the initial admin account: " "Name cannot be empty"
   required_input user_lastname "Last name for the initial admin account: " "Name cannot be empty"
-  password_input user_password
+  password_input user_password "Password for the initial admin account: "
 
   print_brake 72
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -137,7 +137,7 @@ required_input() {
 
 password_input() {
   local result=$1
-  echo -n "* ${2}"
+  echo -en "* ${2}\n"
   while [[ -z "$password_main" || ! $password_main == $password_confirm ]]
     do
       read -sp "Password: " password_main && echo

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -138,12 +138,12 @@ required_input() {
 password_input() {
   local result=$1
   echo -e "Please enter the password that is used throughout the install. (Use something strong)"
-  while [[ -z "$passOriginal" || ! $passOriginal "==" $passConfirm ]]
+  while [[ -z "$passOriginal" || ! "$passOriginal" == "$passConfirm" ]]
     do
       read -rsp "Password: " passOriginal && echo
       read -rsp "Confirm Password: " passConfirm && echo
       [[ -z "$passOriginal" ]] && echo -e "\nError: Password cannot be empty"
-      [[ ! $passOriginal "==" $passConfirm ]] && echo -e "Error: Password do not match\n"
+      [[ ! "$passOriginal" == "$passConfirm" ]] && echo -e "Error: Password do not match\n"
     done
    eval "$result="'$passOriginal'""
 }

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -136,35 +136,16 @@ required_input() {
 }
 
 password_input() {
-  local  __resultvar=$1
-  local  result=''
-
-  while [ -z "$result" ]; do
-    echo -n "* ${2}"
-
-    # modified from https://stackoverflow.com/a/22940001
-    while IFS= read -r -s -n1 char; do
-      [[ -z $char ]] && { printf '\n'; break; } # ENTER pressed; output \n and break.
-      if [[ $char == $'\x7f' ]]; then # backspace was pressed
-          # Only if variable is not empty
-          if [ -n "$result" ]; then
-            # Remove last char from output variable.
-            [[ -n $result ]] && result=${result%?}
-            # Erase '*' to the left.
-            printf '\b \b' 
-          fi
-      else
-        # Add typed char to output variable.
-        result+=$char
-        # Print '*' in its stead.
-        printf '*'
-      fi
+  local result=$1
+  echo -e "Please enter the password that is used throughout the install. (Use something strong)"
+  while [[ -z "$passOriginal" || ! $passOriginal == $passConfirm ]]
+    do
+      read -sp "Password: " passOriginal && echo
+      read -sp "Confirm Password: " passConfirm && echo
+      [[ -z "$passOriginal" ]] && echo -e "\nError: Password cannot be empty"
+      [[ ! $passOriginal == $passConfirm ]] && echo -e "Error: Password do not match\n"
     done
-
-    [ -z "$result" ] && print_error "${3}"
-  done
-
-  eval "$__resultvar="'$result'""
+   eval "$result="'$passOriginal'""
 }
 
 # other functions
@@ -904,7 +885,7 @@ function main {
   [ -z "$MYSQL_USER_INPUT" ] && MYSQL_USER="pterodactyl" || MYSQL_USER=$MYSQL_USER_INPUT
 
   # MySQL password input
-  password_input MYSQL_PASSWORD "Password (use something strong): " "MySQL password cannot be empty"
+  password_input MYSQL_PASSWORD
 
   valid_timezones="$(timedatectl list-timezones)"
   echo "* List of valid timezones here $(hyperlink "https://www.php.net/manual/en/timezones.php")"
@@ -925,7 +906,7 @@ function main {
   required_input user_username "Username for the initial admin account: " "Username cannot be empty"
   required_input user_firstname "First name for the initial admin account: " "Name cannot be empty"
   required_input user_lastname "Last name for the initial admin account: " "Name cannot be empty"
-  password_input user_password "Password for the initial admin account: " "Password cannot be empty"
+  password_input user_password
 
   print_brake 72
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -138,12 +138,12 @@ required_input() {
 password_input() {
   local result=$1
   echo -en "* ${2}\n"
-  while [[ -z "$password_main" || ! $password_main == $password_confirm ]]
+  while [[ -z "$password_main" || ! "$password_main" == "$password_confirm" ]]
     do
       read -sp "Password: " password_main && echo
       read -sp "Confirm Password: " password_confirm && echo
       [[ -z "$password_main" ]] && echo -e "\nError: Password cannot be empty"
-      [[ ! $password_main == $password_confirm ]] && echo -e "Error: Password do not match\n"
+      [[ ! "$password_main" == "$password_confirm" ]] && echo -e "Error: Password do not match\n"
     done
    eval "$result="'$password_main'""
 }

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -138,12 +138,12 @@ required_input() {
 password_input() {
   local result=$1
   echo -e "Please enter the password that is used throughout the install. (Use something strong)"
-  while [[ -z "$passOriginal" || ! $passOriginal == $passConfirm ]]
+  while [[ -z "$passOriginal" || ! $passOriginal "==" $passConfirm ]]
     do
-      read -sp "Password: " passOriginal && echo
-      read -sp "Confirm Password: " passConfirm && echo
+      read -rsp "Password: " passOriginal && echo
+      read -rsp "Confirm Password: " passConfirm && echo
       [[ -z "$passOriginal" ]] && echo -e "\nError: Password cannot be empty"
-      [[ ! $passOriginal == $passConfirm ]] && echo -e "Error: Password do not match\n"
+      [[ ! $passOriginal "==" $passConfirm ]] && echo -e "Error: Password do not match\n"
     done
    eval "$result="'$passOriginal'""
 }

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -138,14 +138,14 @@ required_input() {
 password_input() {
   local result=$1
   echo -e "Please enter the password that is used throughout the install. (Use something strong)"
-  while [[ -z "$passOriginal" || ! "$passOriginal" == "$passConfirm" ]]
+  while [[ -z "$password_main" || ! $password_main == $password_confirm ]]
     do
-      read -rsp "Password: " passOriginal && echo
-      read -rsp "Confirm Password: " passConfirm && echo
-      [[ -z "$passOriginal" ]] && echo -e "\nError: Password cannot be empty"
-      [[ ! "$passOriginal" == "$passConfirm" ]] && echo -e "Error: Password do not match\n"
+      read -sp "Password: " password_main && echo
+      read -sp "Confirm Password: " password_confirm && echo
+      [[ -z "$password_main" ]] && echo -e "\nError: Password cannot be empty"
+      [[ ! $password_main == $password_confirm ]] && echo -e "Error: Password do not match\n"
     done
-   eval "$result="'$passOriginal'""
+   eval "$result="'$password_main'""
 }
 
 # other functions

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -140,8 +140,8 @@ password_input() {
   echo -en "* ${2}\n"
   while [[ -z "$password_main" || ! "$password_main" == "$password_confirm" ]]
     do
-      read -sp "Password: " password_main && echo
-      read -sp "Confirm Password: " password_confirm && echo
+      read -rsp "Password: " password_main && echo
+      read -rsp "Confirm Password: " password_confirm && echo
       [[ -z "$password_main" ]] && echo -e "\nError: Password cannot be empty"
       [[ ! "$password_main" == "$password_confirm" ]] && echo -e "Error: Password do not match\n"
     done


### PR DESCRIPTION
There were issues with the previous one where, if you copy and paste a large password, sometimes it doesn't display the * and displayers the text.
When I first had this come up I didn't want to continue using a stronger password, because I was afriad I would know the password after, since it would be inputted incorrectly.

This follows the traditional style of Linux passwords, when you put in the password, no text comes up when you type, and it asks you to confirm the password with no text still coming up. This should still with with the multiple variables in the script, you can use it by doing `password_input VARIABLE` then the VARIABLE would be the password that is entered.

Haven't tested it using the main script, only tested it sectioned off, since I think its a pretty small change.