### PR TITLE
Use Vagrant for local testing/development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is available at [GitHub](https://github.com/vilhelmprytz/pterodacty
 
 ## Features
 
-- Automatic installation of the Pterodactyl Panel (dependencies,  database, cronjob, nginx).
+- Automatic installation of the Pterodactyl Panel (dependencies, database, cronjob, nginx).
 - Automatic installation of the Pterodactyl Wings (Docker, NodeJS, systemd).
 - Panel: (optional) automatic configuration of Let's Encrypt.
 - Panel: (optional) automatic configuration of UFW (firewall for Ubuntu/Debian).
@@ -28,35 +28,35 @@ List of supported installation setups for panel and Wings (installations support
 
 ### Supported panel operating systems and webservers
 
-| Operating System  | Version | nginx support        | PHP Version |
-| ----------------- | ------- | -------------------- | ----------- |
-| Ubuntu            | 14.04   | :red_circle:         |             |
-|                   | 16.04   | :red_circle: *       |             |
-|                   | 18.04   | :white_check_mark:   | 7.4         |
-|                   | 20.04   | :white_check_mark:   | 7.4         |
-| Debian            | 8       | :red_circle: *       |             |
-|                   | 9       | :white_check_mark:   | 7.4         |
-|                   | 10      | :white_check_mark:   | 7.4         |
-| CentOS            | 6       | :red_circle:         |             |
-|                   | 7       | :white_check_mark:   | 7.4         |
-|                   | 8       | :white_check_mark:   | 7.4         |
+| Operating System | Version | nginx support      | PHP Version |
+| ---------------- | ------- | ------------------ | ----------- |
+| Ubuntu           | 14.04   | :red_circle:       |             |
+|                  | 16.04   | :red_circle: \*    |             |
+|                  | 18.04   | :white_check_mark: | 7.4         |
+|                  | 20.04   | :white_check_mark: | 7.4         |
+| Debian           | 8       | :red_circle: \*    |             |
+|                  | 9       | :white_check_mark: | 7.4         |
+|                  | 10      | :white_check_mark: | 7.4         |
+| CentOS           | 6       | :red_circle:       |             |
+|                  | 7       | :white_check_mark: | 7.4         |
+|                  | 8       | :white_check_mark: | 7.4         |
 
 ### Supported Wings operating systems
 
-| Operating System  | Version | Supported            |
-| ----------------- | ------- | -------------------- |
-| Ubuntu            | 14.04   | :red_circle:         |
-|                   | 16.04   | :red_circle: *       |
-|                   | 18.04   | :white_check_mark:   |
-|                   | 20.04   | :white_check_mark:   |
-| Debian            | 8       | :red_circle:         |
-|                   | 9       | :white_check_mark:   |
-|                   | 10      | :white_check_mark:   |
-| CentOS            | 6       | :red_circle:         |
-|                   | 7       | :white_check_mark:   |
-|                   | 8       | :white_check_mark:   |
+| Operating System | Version | Supported          |
+| ---------------- | ------- | ------------------ |
+| Ubuntu           | 14.04   | :red_circle:       |
+|                  | 16.04   | :red_circle: \*    |
+|                  | 18.04   | :white_check_mark: |
+|                  | 20.04   | :white_check_mark: |
+| Debian           | 8       | :red_circle:       |
+|                  | 9       | :white_check_mark: |
+|                  | 10      | :white_check_mark: |
+| CentOS           | 6       | :red_circle:       |
+|                  | 7       | :white_check_mark: |
+|                  | 8       | :white_check_mark: |
 
-_* Ubuntu 16 and Debian 8 no longer supported since Pterodactyl does not actively support it._
+_\* Ubuntu 16 and Debian 8 no longer supported since Pterodactyl does not actively support it._
 
 ## Using the installation scripts
 
@@ -66,13 +66,40 @@ To use the installation scripts, simply run this command as root. The script wil
 bash <(curl -s https://pterodactyl-installer.se)
 ```
 
-*Note: On some systems, it's required to be already logged in as root before executing the one-line command (where `sudo` is in front of the command does not work).*
+_Note: On some systems, it's required to be already logged in as root before executing the one-line command (where `sudo` is in front of the command does not work)._
 
 Here is a [YouTube video](https://www.youtube.com/watch?v=E8UJhyUFoHM) that illustrates the installation process.
 
 ## Firewall setup
 
 The installation scripts can install and configure a firewall for you. The script will ask whether you want this or not. It is highly recommended to opt-in for the automatic firewall setup.
+
+## Development & Ops
+
+To test the script, we use [Vagrant](https://www.vagrantup.com). With Vagrant, you can quickly get a fresh machine up and running to test the script.
+
+If you want to test the script on all supported installations in one go, just run the following.
+
+```bash
+vagrant up
+```
+
+If you only want to test a specific distribution, you can run the following.
+
+```bash
+vagrant up <name>
+```
+
+Replace name with one of the following (supported installations).
+
+- `ubuntu_focal`
+- `ubuntu_bionic`
+- `debian_buster`
+- `debian_stretch`
+- `centos_8`
+- `centos_7`
+
+Then you can use `vagrant ssh <name of machine>` to SSH into the box. The project directory will be mounted in `/vagrant` so you can quickly modify the script locally and then test the changes by running the script from `/vagrant/install_panel.sh` and `/vagrant/install_wings` respectively.
 
 ## Contributors ✨
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,18 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
-
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://vagrantcloud.com/search.
-
   # "public" network so that we can access the panel interface
   config.vm.network "public_network"
 
@@ -42,58 +31,4 @@ Vagrant.configure("2") do |config|
   config.vm.define "centos_8" do |centos_8|
     centos_8.vm.box = "centos/8"
   end
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # NOTE: This will enable public access to the opened port
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine and only allow access
-  # via 127.0.0.1 to disable public access
-  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,6 +13,9 @@ Vagrant.configure("2") do |config|
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
 
+  # "public" network so that we can access the panel interface
+  config.vm.network "public_network"
+
   # ubuntu
   config.vm.define "ubuntu_focal" do |ubuntu_focal|
     ubuntu_focal.vm.box = "ubuntu/focal64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,96 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+
+  # ubuntu
+  config.vm.define "ubuntu_focal" do |ubuntu_focal|
+    ubuntu_focal.vm.box = "ubuntu/focal64"
+  end
+
+  config.vm.define "ubuntu_bionic" do |ubuntu_bionic|
+    ubuntu_bionic.vm.box = "ubuntu/bionic64"
+  end
+
+  # debian
+  config.vm.define "debian_buster" do |debian_buster|
+    debian_buster.vm.box = "debian/buster64"
+  end
+
+  config.vm.define "debian_stretch" do |debian_stretch|
+    debian_stretch.vm.box = "debian/stretch64"
+  end
+
+  # (centos)
+  config.vm.define "centos_7" do |centos_7|
+    centos_7.vm.box = "centos/7"
+  end
+
+  config.vm.define "centos_8" do |centos_8|
+    centos_8.vm.box = "centos/8"
+  end
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end


### PR DESCRIPTION
Testing the script manually means a lot of work. I've created a `Vagrantfile` so that the script can easily be tested on all supported installations. Simply run `vagrant up ubuntu_focal`  or `vagrant up centos_7` and then `vagrant ssh <name, e.g. ubuntu_focal>` and the script from your project folder (i.e. included with any modifications you are yet to have committed) will be located in `/vagrant` directory.

Still WIP. 