### PR TITLE
Minor changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is available at [GitHub](https://github.com/vilhelmprytz/pterodacty
 ## Features
 
 - Automatic installation of the Pterodactyl Panel (dependencies, database, cronjob, nginx).
-- Automatic installation of the Pterodactyl Wings (Docker, NodeJS, systemd).
+- Automatic installation of the Pterodactyl Wings (Docker, systemd).
 - Panel: (optional) automatic configuration of Let's Encrypt.
 - Panel: (optional) automatic configuration of UFW (firewall for Ubuntu/Debian).
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Unofficial scripts for installing Pterodactyl Panel & Wings. Works with the late
 
 Read more about [Pterodactyl](https://pterodactyl.io/) here. This script is not associated with the official Pterodactyl Project.
 
-This project is available at [GitHub](https://github.com/vilhelmprytz/pterodactyl-installer) with read-only forks available at [GitLab](https://gitlab.com/vilhelm/pterodactyl-installer) and [Bitbucket](https://bitbucket.org/prytz/pterodactyl-installer/src/master/).
-
 ## Features
 
 - Automatic installation of the Pterodactyl Panel (dependencies, database, cronjob, nginx).


### PR DESCRIPTION
- NodeJS is no longer relevant to Pterodactyl (removed mentioning it)
- Remove unnecessary mention of project mirrors