### PR TITLE
wings: centos: replace pterodactyl0 with docker0 trusted zone

### DIFF
--- a/install-wings.sh
+++ b/install-wings.sh
@@ -419,7 +419,7 @@ firewall_firewalld() {
   [ "$CONFIGURE_LETSENCRYPT" == true ] && firewall-cmd --add-service=http --permanent -q # Port 80
   [ "$CONFIGURE_LETSENCRYPT" == true ] && firewall-cmd --add-service=https --permanent -q # Port 443
 
-  firewall-cmd --permanent --zone=trusted --change-interface=pterodactyl0 -q
+  firewall-cmd --permanent --zone=trusted --change-interface=docker0
   firewall-cmd --zone=trusted --add-masquerade --permanent
   firewall-cmd --reload -q # Enable firewall
 


### PR DESCRIPTION
I've had some issues where Wings won't boot on CentOS 7/8 because the interface "isn't trusted" or something like that. Only occurs sometimes for me, but I thought it's worth looking into.