### PR TITLE
panel: Use php8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ List of supported installation setups for panel and Wings (installations support
 | ---------------- | ------- | ------------------ | ----------- |
 | Ubuntu           | 14.04   | :red_circle:       |             |
 |                  | 16.04   | :red_circle: \*    |             |
-|                  | 18.04   | :white_check_mark: | 7.4         |
-|                  | 20.04   | :white_check_mark: | 7.4         |
+|                  | 18.04   | :white_check_mark: | 8.0         |
+|                  | 20.04   | :white_check_mark: | 8.0         |
 | Debian           | 8       | :red_circle: \*    |             |
-|                  | 9       | :white_check_mark: | 7.4         |
-|                  | 10      | :white_check_mark: | 7.4         |
+|                  | 9       | :white_check_mark: | 8.0         |
+|                  | 10      | :white_check_mark: | 8.0         |
 | CentOS           | 6       | :red_circle:       |             |
-|                  | 7       | :white_check_mark: | 7.4         |
-|                  | 8       | :white_check_mark: | 7.4         |
+|                  | 7       | :white_check_mark: | 8.0         |
+|                  | 8       | :white_check_mark: | 8.0         |
 
 ### Supported Wings operating systems
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -501,6 +501,12 @@ ubuntu20_dep() {
   # Ubuntu universe repo
   add-apt-repository universe
 
+  # Add PPA for PHP (we need 8.0 and focal only has 7.4)
+  LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
+
+  # Update repositories list
+  apt_update
+
   # Install Dependencies
   apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server redis cron
 

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -596,8 +596,8 @@ centos7_dep() {
   # Add remi repo (php8.0)
   yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm
   yum install -y yum-utils
-  yum-config-manager -y --disable remi-php80
-  yum-config-manager -y --enable remi-php74
+  yum-config-manager -y --disable remi-php54
+  yum-config-manager -y --enable remi-php80
   yum_update
 
   # Install MariaDB

--- a/install-panel.sh
+++ b/install-panel.sh
@@ -277,12 +277,12 @@ detect_distro() {
 check_os_comp() {
   case "$OS" in
     ubuntu)
-      PHP_SOCKET="/run/php/php7.4-fpm.sock"
+      PHP_SOCKET="/run/php/php8.0-fpm.sock"
       [ "$OS_VER_MAJOR" == "18" ] && SUPPORTED=true
       [ "$OS_VER_MAJOR" == "20" ] && SUPPORTED=true
       ;;
     debian)
-      PHP_SOCKET="/run/php/php7.4-fpm.sock"
+      PHP_SOCKET="/run/php/php8.0-fpm.sock"
       [ "$OS_VER_MAJOR" == "9" ] && SUPPORTED=true
       [ "$OS_VER_MAJOR" == "10" ] && SUPPORTED=true
       ;;
@@ -502,7 +502,7 @@ ubuntu20_dep() {
   add-apt-repository universe
 
   # Install Dependencies
-  apt -y install php7.4 php7.4-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server redis cron
+  apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server redis cron
 
   # Enable services
   enable_services_debian_based
@@ -519,7 +519,7 @@ ubuntu18_dep() {
   # Ubuntu universe repo
   add-apt-repository universe
 
-  # Add PPA for PHP (we need 7.3+ and bionic only has 7.2)
+  # Add PPA for PHP (we need 8.0 and bionic only has 7.2)
   LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php
 
   # Add the MariaDB repo (bionic has mariadb version 10.1 and we need newer than that)
@@ -529,7 +529,7 @@ ubuntu18_dep() {
   apt_update
 
   # Install Dependencies
-  apt -y install php7.4 php7.4-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server redis cron
+  apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx tar unzip git redis-server redis cron
 
   # Enable services
   enable_services_debian_based
@@ -543,8 +543,7 @@ debian_stretch_dep() {
   # MariaDB need dirmngr
   apt -y install dirmngr
 
-  # install PHP 7.4 using sury's repo instead of PPA
-  # this guide shows how: https://vilhelmprytz.se/2018/08/22/install-php72-on-Debian-8-and-9.html
+  # install PHP 8.0 using sury's repo instead of PPA
   apt install ca-certificates apt-transport-https lsb-release -y
   wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
   echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list
@@ -556,7 +555,7 @@ debian_stretch_dep() {
   apt_update
 
   # Install Dependencies
-  apt -y install php7.4 php7.4-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx curl tar unzip git redis-server cron
+  apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx curl tar unzip git redis-server cron
 
   # Enable services
   enable_services_debian_based
@@ -570,7 +569,7 @@ debian_dep() {
   # MariaDB need dirmngr
   apt -y install dirmngr
 
-  # install PHP 7.4 using sury's repo instead of default 7.2 package (in buster repo)
+  # install PHP 8.0 using sury's repo instead of default 7.2 package (in buster repo)
   # this guide shows how: https://vilhelmprytz.se/2018/08/22/install-php72-on-Debian-8-and-9.html
   apt install ca-certificates apt-transport-https lsb-release -y
   wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
@@ -580,7 +579,7 @@ debian_dep() {
   apt_update
 
   # install dependencies
-  apt -y install php7.4 php7.4-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx curl tar unzip git redis-server cron
+  apt -y install php8.0 php8.0-{cli,gd,mysql,pdo,mbstring,tokenizer,bcmath,xml,fpm,curl,zip} mariadb-server nginx curl tar unzip git redis-server cron
 
   # Enable services
   enable_services_debian_based
@@ -594,10 +593,10 @@ centos7_dep() {
   # SELinux tools
   yum install -y policycoreutils policycoreutils-python selinux-policy selinux-policy-targeted libselinux-utils setroubleshoot-server setools setools-console mcstrans
 
-  # Add remi repo (php7.4)
+  # Add remi repo (php8.0)
   yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-7.rpm
   yum install -y yum-utils
-  yum-config-manager -y --disable remi-php54
+  yum-config-manager -y --disable remi-php80
   yum-config-manager -y --enable remi-php74
   yum_update
 
@@ -622,9 +621,9 @@ centos8_dep() {
   # SELinux tools
   dnf install -y policycoreutils selinux-policy selinux-policy-targeted setroubleshoot-server setools setools-console mcstrans
 
-  # add remi repo (php7.4)
+  # add remi repo (php8.0)
   dnf install -y epel-release http://rpms.remirepo.net/enterprise/remi-release-8.rpm
-  dnf module enable -y php:remi-7.4
+  dnf module enable -y php:remi-8.0
   dnf_update
 
   dnf install -y php php-common php-fpm php-cli php-json php-mysqlnd php-gd php-mbstring php-pdo php-zip php-bcmath php-dom php-opcache


### PR DESCRIPTION
Use `php8.0` instead of `php7.4`. `PHP 8` is supported since panel `v1.3.0`

Everything should work as expected as it basically was find 7.4 and replace it with 8.0. (Mostly because `sury` repo includes `8.0`)

Tested on `Debian 10`
