### PR TITLE
panel: fix `ln` bug if file exist

### DIFF
--- a/install-panel.sh
+++ b/install-panel.sh
@@ -814,7 +814,7 @@ configure_nginx() {
     [ "$OS" == "debian" ] && [ "$OS_VER_MAJOR" == "9" ] && sed -i 's/ TLSv1.3//' /etc/nginx/sites-available/pterodactyl.conf
 
     # enable pterodactyl
-    ln -s /etc/nginx/sites-available/pterodactyl.conf /etc/nginx/sites-enabled/pterodactyl.conf
+    ln -sf /etc/nginx/sites-available/pterodactyl.conf /etc/nginx/sites-enabled/pterodactyl.conf
   fi
 
   if [ "$ASSUME_SSL" == false ] && [ "$CONFIGURE_LETSENCRYPT" == false ]; then


### PR DESCRIPTION
Fixed a critical bug if `configure_nginx` is run again and `ln` fails, because the file exists. I added the `-f` flag so it forces to remove the file, if it already exists.

fixes #186 