### PR TITLE
"Ecnrypt" -> "Encrypt" typo fixed

### DIFF
--- a/lib/verify-fqdn.sh
+++ b/lib/verify-fqdn.sh
@@ -59,7 +59,7 @@ error() {
 
 fail() {
   output "The DNS record ($dns_record) does not match your server IP. Please make sure the FQDN $fqdn is pointing to the IP of your server, $ip"
-  output "If you are using Cloudflare, please disable the proxy or opt out from Let's Ecnrypt."
+  output "If you are using Cloudflare, please disable the proxy or opt out from Let's Encrypt."
 
   echo -n "* Proceed anyways (your install will be broken if you do not know what you are doing)? (y/N): "
   read -r override


### PR DESCRIPTION
While installing I noticed a typo, fixed!
"Ecnrypt" -> "Encrypt"

Fixes #193