### PR TITLE
Allow CNAME DNS records

### DIFF
--- a/lib/verify-fqdn.sh
+++ b/lib/verify-fqdn.sh
@@ -90,7 +90,7 @@ dns_verify() {
   output "Resolving DNS for $fqdn"
   ip=$(curl -4 -s $CHECKIP_URL)
   dns_record=$(dig +short @$DNS_SERVER "$fqdn")
-  [[ $dns_record != *"$ip"* ]] && fail
+  [ "${ip}" != "${dns_record} | tail -n1" ] && fail
   output "DNS verified!"
 }
 

--- a/lib/verify-fqdn.sh
+++ b/lib/verify-fqdn.sh
@@ -90,7 +90,7 @@ dns_verify() {
   output "Resolving DNS for $fqdn"
   ip=$(curl -4 -s $CHECKIP_URL)
   dns_record=$(dig +short @$DNS_SERVER "$fqdn")
-  [ "${ip}" != "${dns_record}" ] && fail
+  [[ $dns_record != *"$ip"* ]] && fail
   output "DNS verified!"
 }
 

--- a/lib/verify-fqdn.sh
+++ b/lib/verify-fqdn.sh
@@ -89,8 +89,8 @@ confirm() {
 dns_verify() {
   output "Resolving DNS for $fqdn"
   ip=$(curl -4 -s $CHECKIP_URL)
-  dns_record=$(dig +short @$DNS_SERVER "$fqdn")
-  [ "${ip}" != "${dns_record} | tail -n1" ] && fail
+  dns_record=$(dig +short @$DNS_SERVER "$fqdn" | tail -n1)
+  [ "${ip}" != "${dns_record}" ] && fail
   output "DNS verified!"
 }
 


### PR DESCRIPTION
Disclaimer: I have only tested this in an online bash shell, please check if it properly works.

This should fix the situation where a CNAME record is used to point to a domain that points to the proper IP address.
It does break when someone uses a domain that contains the IP address but does not point to the IP address, but I think that's an bigger edge case than using CNAME records.

I'm open for other suggestions 😃 

Fixes #201

