### PR TITLE
wings: Fix checking of virtualization

### DIFF
--- a/install-wings.sh
+++ b/install-wings.sh
@@ -251,7 +251,7 @@ check_os_comp() {
   virt_serv=$(virt-what)
 
   case "$virt_serv" in
-  openvz | lxc)
+  *openvz* | *lxc*)
     print_warning "Unsupported type of virtualization detected. Please consult with your hosting provider whether your server can run Docker or not. Proceed at your own risk."
     echo -e -n "* Are you sure you want to proceed? (y/N): "
     read -r CONFIRM_PROCEED


### PR DESCRIPTION
Make so that the script checks for openvz or lxc anywhere in the `virt-what` output.

Fixes #200