### PR TITLE
Update PROXMOX NESTING

### DIFF
--- a/install-wings.sh
+++ b/install-wings.sh
@@ -293,7 +293,7 @@ check_os_comp() {
   virt_serv=$(virt-what)
 
   case "$virt_serv" in
-  *openvz* | *lxc*)
+  *openvz* )
     print_warning "Unsupported type of virtualization detected. Please consult with your hosting provider whether your server can run Docker or not. Proceed at your own risk."
     echo -e -n "* Are you sure you want to proceed? (y/N): "
     read -r CONFIRM_PROCEED


### PR DESCRIPTION
FR : Juste la désactivation de la détection LCX car sur PROXMOX, on peut utiliser docker sur lcx avec l'option nesting in container.
EN : Just the deactivation of the LCX detection because on PROXMOX, we can use docker on lcx with nesting in container option.

<!-- Include all your changes, either in written form or as a list. Try to be as clear as possible. -->

Fixes #??
<!-- include the issue number if this pull request is fixing that issue -->
