### PR TITLE
Fix incorrectly labeled setup option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,7 +102,7 @@ while [ "$done" == false ]; do
 
     "Install panel with canary version of the script (the versions that lives in master, may be broken!)"
     "Install Wings with canary version of the script (the versions that lives in master, may be broken!)"
-    "Install both [5] and [6] on the same machine (wings script runs after panel)"
+    "Install both [6] and [7] on the same machine (wings script runs after panel)"
   )
 
   actions=(


### PR DESCRIPTION
The setup option refers options five and six (legacy panel+wings and canary panel), this should be six and seven (canary panel and canary wings)