### PR TITLE
Fix virt-what not found

### DIFF
--- a/install-wings.sh
+++ b/install-wings.sh
@@ -311,6 +311,8 @@ check_os_comp() {
     exit 1
   fi
 
+  export PATH="$PATH:/sbin:/usr/sbin"
+
   virt_serv=$(virt-what)
 
   case "$virt_serv" in


### PR DESCRIPTION
Always add export `/sbin:/usr/sbin` to `$PATH`.